### PR TITLE
Add Ideas section to nightly codebase review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,3 +8,24 @@ When working through tasks:
 - If a task is unclear, comment explaining what you need and label it 'needs-input'
 - Never delete files without explicit instruction
 - Keep all communication simple and non-technical
+
+## For Nightly Codebase Reviews
+
+When generating the nightly codebase review, always include a dedicated **Ideas for Each Project** section AFTER the Priority Actions section. This section should go beyond maintenance suggestions and focus on exciting, forward-thinking enhancements.
+
+For each project, provide 2-3 creative ideas such as:
+- A new feature that could delight customers or save Kenny serious time
+- An AI-powered enhancement using Claude or other AI tools
+- A new integration with tools Kenny already uses (GHL, Airtable, Make.com, Slack, Resend)
+- A monetization angle or upsell opportunity Kenny hasn't tapped yet
+
+Also include a **New Project Ideas** sub-section with 2-3 ideas for entirely new tools Kenny could build, based on his businesses (Fleet Shield SaaS, Nilo Agency B2B lead gen, Combilift forklift sales in Florida).
+
+Format example:
+## Ideas for Each Project
+
+### {Project Name}
+- IDEA: {Title} — {1-2 sentences on what and why}
+
+### New Project Ideas
+- NEW PROJECT: {Title} — {2-3 sentences on what it would do and why Kenny should build it}


### PR DESCRIPTION
## What this does

This update adds a dedicated **Ideas for Each Project** section to the nightly codebase review by updating the CLAUDE.md instructions file.

Starting tonight, the nightly review email will include:
- **2-3 creative enhancement ideas** for each of your 7 projects
- Ideas focused on new features, AI improvements, integrations with GHL/Airtable/Make.com, and revenue opportunities
- A **New Project Ideas** section with 2-3 ideas for brand new tools you could build based on Fleet Shield, Nilo Agency, and Combilift

**This resolves Issue #13.**

Note: The nightly review workflow file also has improvements staged (better Ideas prompting), but applying those requires the GitHub PAT to have 'workflow' scope. The CLAUDE.md approach here will still add the Ideas section to every nightly review starting immediately.