### PR TITLE
Fix nightly review: add Write tool to allowed_tools

### DIFF
--- a/.github/workflows/nightly-review.yml
+++ b/.github/workflows/nightly-review.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GH_PAT }}
-          allowed_tools: "Bash(gh *),Bash(cat *),Read,Glob,Grep"
+          allowed_tools: "Bash(gh *),Bash(cat *),Read,Write,Glob,Grep"
           prompt: |
             Read the CLAUDE.md file in this repository for context about who you're working for.
 


### PR DESCRIPTION
## Summary\n- The nightly codebase review workflow tells Claude to write `review-report.txt` using the Write tool, but Write wasn't listed in `allowed_tools` — so the step failed\n- This adds `Write` to the allowed tools list so the report file can actually be created and the email gets sent\n\n## Test plan\n- [ ] Merge this PR\n- [ ] Trigger a manual run of the \"Nightly Codebase Review\" workflow and confirm it completes successfully\n\nhttps://claude.ai/code/session_016pbfKDbDcB2xPWd5x5uFpq