### PR TITLE
Re-enable nightly review cron and scope to 4 repos

### DIFF
--- a/.github/workflows/nightly-review.yml
+++ b/.github/workflows/nightly-review.yml
@@ -1,9 +1,8 @@
 name: Nightly Codebase Review
 
 on:
-  # Nightly schedule disabled — run manually from the Actions tab when needed.
-  # schedule:
-  #   - cron: '30 5 * * *'
+  schedule:
+    - cron: '30 5 * * *'
 
   # Allow manual triggering from the GitHub Actions UI
   workflow_dispatch:
@@ -39,15 +38,12 @@ jobs:
             Your job is to inspect each repo and write a clear, helpful email with suggestions
             for improving each project. Keep everything in plain, simple English — Kenny is not a developer.
 
-            Use the gh CLI to inspect these 7 repositories owned by nilolabs6901:
+            Use the gh CLI to inspect these 4 repositories owned by nilolabs6901:
 
-            1. repairiq-final
-            2. forklift-fleet-manager
-            3. sales-sherpa-dashboard
-            4. overnight-tasks
-            5. combilift-prospecting
-            6. old-distill-bill
-            7. deal-registration-app
+            1. paperclip-combilift
+            2. Telegram-bot-starter
+            3. Important-doc-autoMation
+            4. cardnurture
 
             For EACH repo, do the following:
             - Run: gh repo view nilolabs6901/{repo} --json description,updatedAt,pushedAt


### PR DESCRIPTION
## Why

The nightly review emails stopped arriving after Apr 20. Root cause: PR #56 ("Disable nightly cron schedules for overnight automation") commented out the `schedule:` trigger on `nightly-review.yml`, so the workflow only ran on manual dispatch. All 38 prior runs were green — nothing was broken, the job just wasn't being kicked off.

A side note from the previous debugging session was that PR #56 had "scoped the review to 4 repos" — that wasn't accurate. The repo list in the prompt was never touched by #56, so it still listed the original 7 repos.

## What changed

`.github/workflows/nightly-review.yml`:

1. **Re-enabled the cron schedule** (`30 5 * * *`, ~1:30 AM ET) so the review runs automatically again.
2. **Scoped the prompt to 4 repos** per Kenny's instruction:
   - `paperclip-combilift`
   - `Telegram-bot-starter`
   - `Important-doc-autoMation`
   - `cardnurture`

## Not included (flagging for Kenny)

The sibling workflow `overnight-tasks.yml` (the one that processes `tonight`-labeled issues) is also disabled by the same PR #56. Left untouched since it wasn't part of this request — re-enable separately if desired.

## Test plan

- [ ] Merge to `main`
- [ ] Manually trigger the workflow from the Actions tab once to confirm it runs end-to-end against the new 4-repo list and email arrives at team@niloagency.com
- [ ] Wait for next scheduled run (~1:30 AM ET) and confirm email arrives automatically


---
_Generated by [Claude Code](https://claude.ai/code/session_017n55vrHweLEKTuULWZcvNM)_