### PR TITLE
Make nightly review resilient when Claude step fails

### DIFF
--- a/.github/workflows/nightly-review.yml
+++ b/.github/workflows/nightly-review.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GH_PAT }}
-          allowed_tools: "Bash(gh *),Bash(git *),Bash(date *),Bash(sort *),Bash(uniq *),Bash(head *),Bash(cat *),Bash(awk *),Bash(grep *),Read,Write,Glob,Grep"
+          allowed_tools: "Bash(gh *),Bash(git *),Bash(date *),Bash(sort *),Bash(uniq *),Bash(head *),Bash(tail *),Bash(cat *),Bash(awk *),Bash(grep *),Bash(sed *),Bash(wc *),Bash(ls *),Bash(find *),Bash(echo *),Bash(test *),Bash(true *),Read,Write,Glob,Grep"
           prompt: |
             Read the CLAUDE.md file in this repository for context about who you're working for.
 
@@ -175,7 +175,25 @@ jobs:
             Write the COMPLETE email body to "review-report.txt" using the Write tool.
             Start with: "Hey Kenny, here's your nightly codebase review for today."
 
+      - name: Ensure report file exists
+        if: always()
+        run: |
+          if [ ! -s review-report.txt ]; then
+            cat > review-report.txt <<EOF
+          Hey Kenny — tonight's codebase review didn't complete successfully.
+
+          The automated review step exited before producing a report. The GitHub
+          Actions log for run #${{ github.run_number }} has the details:
+          ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          A backup issue has been opened in the overnight-tasks repo so this
+          doesn't get lost. No action needed from you tonight — Claude will
+          investigate on the next session.
+          EOF
+          fi
+
       - name: Send email report
+        if: always()
         uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com


### PR DESCRIPTION
## Why
Tonight's Nightly Codebase Review run failed with "All jobs have failed" and produced issue #73 with the fallback message **"Review did not produce output. Check the Actions log."** The Claude review step exited before writing `review-report.txt`, which then cascaded into the email step failing too — so you only saw a generic backup issue instead of any useful signal.

## What this changes
1. **Fallback report file** — new "Ensure report file exists" step (`if: always()`) writes a short stub with a direct link to the failed Actions run, so the email + backup issue always carry useful info.
2. **Email step is `if: always()`** — you'll get notified on failure too, instead of the email being silently skipped.
3. **Wider `allowed_tools`** — added `sed`, `wc`, `ls`, `find`, `echo`, `test`, `tail` patterns so the deep-review prompt's shell pipelines are less likely to be blocked.

## What this does NOT do
This doesn't fix the underlying cause of tonight's failure — that needs the Actions log from run #73's parent run. But it does make the next failure self-explaining instead of silent.

## Test plan
- [ ] Trigger the workflow manually from the Actions tab (`workflow_dispatch`) and confirm the email arrives even on a forced failure.
- [ ] Confirm the fallback file links back to the correct run URL.

---
_Generated by [Claude Code](https://claude.ai/code/session_017pDbggEVGi2AwPNA76YYxu)_